### PR TITLE
Fix inconsistent behaviour for users with insufficient permissions

### DIFF
--- a/timetable/tests.py
+++ b/timetable/tests.py
@@ -82,7 +82,7 @@ class TimetableStatusCodeTest(TestCase):
         self.client.force_login(self.user)
         for url in self.restricted_urls:
             response = self.client.get(self.app_prefix + url)
-            self.assertEqual(response.status_code, 302)
+            self.assertEqual(response.status_code, 403)
         self.client.logout()
 
 class DefaultTimetableTest(TestCase):

--- a/timetable/views.py
+++ b/timetable/views.py
@@ -125,7 +125,8 @@ class AddSubstitutionsView1(PermissionRequiredMixin, FormView):
         return context
 
 @never_cache
-@permission_required('timetable.add_substitution')
+@login_required
+@permission_required('timetable.add_substitution',raise_exception=True)
 def add_substitutions2(request, teacher_id, date):
     date = parse_date(date)
     teacher = get_object_or_404(Teacher, pk=teacher_id)
@@ -146,7 +147,8 @@ def add_substitutions2(request, teacher_id, date):
     return render(request, 'add_substitutions.html', context)
 
 @never_cache
-@permission_required('timetable.add_dayplan')
+@login_required
+@permission_required('timetable.add_dayplan',raise_exception=True)
 def edit_calendar(request):
     qs = DayPlan.objects.filter(date__gte=date.today())
     if request.method == 'POST':
@@ -197,7 +199,8 @@ def display(request):
     context = get_display_context()
     return render(request, 'display.html', context)
 
-@permission_required('timetable.add_substitution')
+@login_required
+@permission_required('timetable.add_substitution',raise_exception=True)
 def delete_substitution(request, substitution_id):
     if request.POST:
         obj = get_object_or_404(Substitution, pk=substitution_id)

--- a/timetable/views.py
+++ b/timetable/views.py
@@ -126,7 +126,7 @@ class AddSubstitutionsView1(PermissionRequiredMixin, FormView):
 
 @never_cache
 @login_required
-@permission_required('timetable.add_substitution',raise_exception=True)
+@permission_required('timetable.add_substitution', raise_exception=True)
 def add_substitutions2(request, teacher_id, date):
     date = parse_date(date)
     teacher = get_object_or_404(Teacher, pk=teacher_id)
@@ -148,7 +148,7 @@ def add_substitutions2(request, teacher_id, date):
 
 @never_cache
 @login_required
-@permission_required('timetable.add_dayplan',raise_exception=True)
+@permission_required('timetable.add_dayplan', raise_exception=True)
 def edit_calendar(request):
     qs = DayPlan.objects.filter(date__gte=date.today())
     if request.method == 'POST':
@@ -200,7 +200,7 @@ def display(request):
     return render(request, 'display.html', context)
 
 @login_required
-@permission_required('timetable.add_substitution',raise_exception=True)
+@permission_required('timetable.add_substitution', raise_exception=True)
 def delete_substitution(request, substitution_id):
     if request.POST:
         obj = get_object_or_404(Substitution, pk=substitution_id)


### PR DESCRIPTION
Due to change in Django 2.1 logged in users will get 403 when accessing view with insufficient permissions. This change applies to PermissionRequiredMixin only. In case of function based views users are redirected to login page with error message above login form.
[https://docs.djangoproject.com/en/2.1/topics/auth/default/#redirecting-unauthorized-requests-in-class-based-views](https://docs.djangoproject.com/en/2.1/topics/auth/default/#redirecting-unauthorized-requests-in-class-based-views)