### PR TITLE
Fixed bug in adding substitutions

### DIFF
--- a/timetable/forms.py
+++ b/timetable/forms.py
@@ -83,7 +83,7 @@ class BaseSubstitutionFormSet(BaseModelFormSet):
             .select_related() \
             .order_by('lesson__period')
         self.teacher = teacher
-        self.teachers = Teacher.objects.all() # So as not to repeat queries
+        self.teachers = Teacher.objects.all().exclude(id=teacher.id) # So as not to repeat queries
         self.date = date
         self.lessons = Lesson.objects \
             .filter(teacher=teacher, weekday=date.weekday()) \


### PR DESCRIPTION
Nauczyciel zastępowany i zastępca mogły być tą samą osobą. Teraz nie mogą.